### PR TITLE
feat: add digital input trigger buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 | Platform        | Description                                              |
 |-----------------|----------------------------------------------------------|
 | `binary_sensor` | Show flags/binary data from `GetState.csv` API.          |
+| `button`        | Momentary triggers for the four digital inputs.          |
 | `light`         | DMX-channel lights (dimmer / RGB / RGBW) configured via the integration's options. |
 | `number`        | Dosage relay timer/countdown in seconds.                 |
 | `select`        | `Auto`/`On`/`Off` dropdowns for relays.                  |

--- a/custom_components/proconip_pool_controller/__init__.py
+++ b/custom_components/proconip_pool_controller/__init__.py
@@ -22,6 +22,7 @@ from .coordinator import ProconipPoolControllerDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.LIGHT,
     Platform.NUMBER,
     Platform.SELECT,

--- a/custom_components/proconip_pool_controller/api.py
+++ b/custom_components/proconip_pool_controller/api.py
@@ -6,6 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from proconip import (
     ConfigObject,
+    DigitalInputControl,
     DmxControl,
     DosageControl,
     GetDmxData,
@@ -42,6 +43,9 @@ class ProconipApiClient:
             client_session=self._session, config=self._api_config
         )
         self._dmx_control_api = DmxControl(client_session=self._session, config=self._api_config)
+        self._digital_input_control_api = DigitalInputControl(
+            client_session=self._session, config=self._api_config
+        )
         self._most_recent_data: GetStateData | None = None
 
     async def async_get_data(
@@ -121,6 +125,15 @@ class ProconipApiClient:
         """Start pH plus dosage for given amount of time."""
         return await self._dosage_control_api.async_ph_plus_dosage(
             dosage_duration=duration_in_seconds,
+        )
+
+    async def async_trigger_digital_input(
+        self,
+        digital_input_id: int,
+    ) -> str:
+        """Trigger (momentarily pulse) the digital input with given id."""
+        return await self._digital_input_control_api.async_trigger(
+            digital_input_id=digital_input_id,
         )
 
     async def async_get_dmx(self) -> GetDmxData:

--- a/custom_components/proconip_pool_controller/button.py
+++ b/custom_components/proconip_pool_controller/button.py
@@ -1,0 +1,64 @@
+"""Button platform for proconip."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from proconip import DIGITAL_INPUT_COUNT
+
+from .const import DOMAIN
+from .coordinator import ProconipPoolControllerDataUpdateCoordinator
+from .entity import ProconipPoolControllerEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_devices: AddEntitiesCallback
+) -> None:
+    """Set up the button platform."""
+    coordinator: ProconipPoolControllerDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_devices(
+        ProconipDigitalInputTriggerButton(
+            coordinator=coordinator,
+            digital_input_no=i + 1,
+            instance_id=entry.entry_id,
+        )
+        for i in range(DIGITAL_INPUT_COUNT)
+    )
+
+
+class ProconipDigitalInputTriggerButton(ProconipPoolControllerEntity, ButtonEntity):
+    """ProCon.IP digital input trigger button class.
+
+    A stateless momentary control that pulses one digital input, mirroring the
+    push buttons in the controller's native web UI. The read-only digital-input
+    sensors report state; this triggers it.
+    """
+
+    _attr_icon = "mdi:gesture-tap-button"
+    _attr_translation_key = "digital_input_trigger"
+
+    def __init__(
+        self,
+        coordinator: ProconipPoolControllerDataUpdateCoordinator,
+        digital_input_no: int,
+        instance_id: str,
+    ) -> None:
+        """Initialize the digital input trigger button."""
+        super().__init__(coordinator=coordinator)
+        self._digital_input_id = digital_input_no - 1
+        self._digital_input = self.coordinator.data.digital_input_objects[self._digital_input_id]
+        self._attr_entity_registry_visible_default = self._digital_input.name != "n.a."
+        self._attr_translation_placeholders = {
+            "sensor_no": str(digital_input_no),
+            "device_name": self._digital_input.name,
+        }
+        self._attr_unique_id = f"digital_input_trigger_{digital_input_no}_{instance_id}"
+
+    async def async_press(self) -> None:
+        """Trigger the digital input with a momentary pulse."""
+        await self.coordinator.client.async_trigger_digital_input(
+            digital_input_id=self._digital_input_id,
+        )
+        await self.coordinator.async_request_refresh()

--- a/custom_components/proconip_pool_controller/manifest.json
+++ b/custom_components/proconip_pool_controller/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ylabonte/proconip-hass/issues",
   "requirements": [
-    "proconip>=2.1.2"
+    "proconip>=2.2.0"
   ],
   "version": "2.0.0"
 }

--- a/custom_components/proconip_pool_controller/translations/de.json
+++ b/custom_components/proconip_pool_controller/translations/de.json
@@ -103,6 +103,11 @@
             "dmx_extension_enabled": {"name": "DMX-Erweiterung aktiviert"},
             "problem": {"name": "Problem"}
         },
+        "button": {
+            "digital_input_trigger": {
+                "name": "Digitalen Eingang Nr. {sensor_no} auslösen: {device_name}"
+            }
+        },
         "sensor": {
             "redox": {"name": "Redox-Sensor"},
             "ph": {"name": "pH-Sensor"},

--- a/custom_components/proconip_pool_controller/translations/en.json
+++ b/custom_components/proconip_pool_controller/translations/en.json
@@ -103,6 +103,11 @@
             "dmx_extension_enabled": {"name": "DMX Extension enabled"},
             "problem": {"name": "Problem"}
         },
+        "button": {
+            "digital_input_trigger": {
+                "name": "Trigger Digital Input No. {sensor_no}: {device_name}"
+            }
+        },
         "sensor": {
             "redox": {"name": "Redox sensor"},
             "ph": {"name": "pH sensor"},

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,104 @@
+"""Tests for the button platform (digital input triggers)."""
+
+from __future__ import annotations
+
+import pytest
+from aioresponses import aioresponses
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.proconip_pool_controller.const import DOMAIN
+
+from .conftest import BASE_URL
+
+USRCFG_URL = f"{BASE_URL}/usrcfg.cgi"
+GET_STATE_URL = f"{BASE_URL}/GetState.csv"
+
+# Device-name prefix HA composes onto every friendly_name (NAME in const.py),
+# because the base entity sets `_attr_has_entity_name = True`.
+DEVICE_PREFIX = "ProCon.IP Pool Controller"
+
+
+def _usrcfg_posts(m: aioresponses) -> list:
+    return [
+        call
+        for (method, url), calls in m.requests.items()
+        for call in calls
+        if method == "POST" and "usrcfg.cgi" in str(url)
+    ]
+
+
+def _state_gets(m: aioresponses) -> int:
+    return sum(
+        len(calls)
+        for (method, url), calls in m.requests.items()
+        if method == "GET" and "GetState.csv" in str(url)
+    )
+
+
+async def test_button_entities_created(
+    hass: HomeAssistant,
+    setup_integration: MockConfigEntry,
+) -> None:
+    """One trigger button per digital input (4), with instance-suffixed ids."""
+    entry = setup_integration
+    registry = er.async_get(hass)
+    for n in range(1, 5):
+        eid = registry.async_get_entity_id(
+            "button", DOMAIN, f"digital_input_trigger_{n}_{entry.entry_id}"
+        )
+        assert eid, f"digital input trigger button {n} not registered"
+    # Fixture names all four inputs (TASTER1..4), so all four are visible.
+    assert len(hass.states.async_entity_ids("button")) == 4
+
+
+async def test_button_press_triggers_and_refreshes(
+    hass: HomeAssistant,
+    setup_integration: MockConfigEntry,
+    mock_state_endpoint: aioresponses,
+) -> None:
+    """Pressing sends the press+release POSTs and refreshes the coordinator."""
+    mock_state_endpoint.post(USRCFG_URL, status=200, body="OK", repeat=True)
+    entry = setup_integration
+    eid = er.async_get(hass).async_get_entity_id(
+        "button", DOMAIN, f"digital_input_trigger_1_{entry.entry_id}"
+    )
+    assert eid
+
+    gets_before = _state_gets(mock_state_endpoint)
+    await hass.services.async_call("button", "press", {"entity_id": eid}, blocking=True)
+
+    posts = _usrcfg_posts(mock_state_endpoint)
+    # Button 1 -> digital_input_id 0 -> mask 1; press then release.
+    assert [p.kwargs["data"] for p in posts] == ["IO=1&WEBIO=1", "IO=0&WEBIO=1"]
+    # A coordinator refresh (extra GetState.csv) followed the press.
+    assert _state_gets(mock_state_endpoint) > gets_before
+
+
+@pytest.mark.parametrize(
+    "language,expected",
+    [
+        ("en", f"{DEVICE_PREFIX} Trigger Digital Input No. 1: TASTER1"),
+        ("de", f"{DEVICE_PREFIX} Digitalen Eingang Nr. 1 auslösen: TASTER1"),
+    ],
+)
+async def test_button_friendly_name_follows_language(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_state_endpoint: aioresponses,
+    language: str,
+    expected: str,
+) -> None:
+    """The trigger button resolves a translated friendly name per language."""
+    hass.config.language = language
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    eid = er.async_get(hass).async_get_entity_id(
+        "button", DOMAIN, f"digital_input_trigger_1_{config_entry.entry_id}"
+    )
+    assert eid
+    state = hass.states.get(eid)
+    assert state is not None
+    assert state.attributes["friendly_name"] == expected

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -76,6 +76,37 @@ async def test_button_press_triggers_and_refreshes(
     assert _state_gets(mock_state_endpoint) > gets_before
 
 
+async def test_button_hidden_by_default_when_input_unnamed(
+    hass: HomeAssistant,
+    get_state_csv: str,
+    aio_mock: aioresponses,
+    config_entry: MockConfigEntry,
+) -> None:
+    """An ``n.a.``-named digital input still gets a button, hidden by default."""
+    # Rename the first digital input (column 24) to "n.a." in the served CSV.
+    lines = get_state_csv.splitlines()
+    names = lines[1].split(",")
+    names[24] = "n.a."
+    lines[1] = ",".join(names)
+    aio_mock.get(f"{BASE_URL}/GetState.csv", status=200, body="\n".join(lines) + "\n", repeat=True)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    unnamed = registry.async_get_entity_id(
+        "button", DOMAIN, f"digital_input_trigger_1_{config_entry.entry_id}"
+    )
+    named = registry.async_get_entity_id(
+        "button", DOMAIN, f"digital_input_trigger_2_{config_entry.entry_id}"
+    )
+    assert unnamed and named
+    # The unnamed input's button is created but hidden by default; the named
+    # one stays visible.
+    assert registry.async_get(unnamed).hidden_by is not None
+    assert registry.async_get(named).hidden_by is None
+
+
 @pytest.mark.parametrize(
     "language,expected",
     [


### PR DESCRIPTION
## What & why

Adds **trigger buttons for the four digital inputs** — the inverse of the
existing read-only digital-input sensors. The ProCon.IP web UI exposes each
input as a momentary push button; this brings that to Home Assistant.

Backed by the new `proconip` 2.2.0 API (released): pressing delegates to
`DigitalInputControl.async_trigger`, which does press → ~600ms hold → release
(`IO=<mask>&WEBIO=1` then `IO=0&WEBIO=1`), then the coordinator refreshes so any
downstream state change surfaces.

HA design: **Button entities** are the idiomatic match for a stateless momentary
action, and `button.press` covers automations — no custom service needed.

## Changes

- `manifest.json` — require `proconip>=2.2.0`.
- `button.py` (new) — `ProconipDigitalInputTriggerButton`, one per input (4),
  visibility mirrors the sensors (hidden when name is `n.a.`), unique_id
  suffixed with the instance id. Uses the library's exported
  `DIGITAL_INPUT_COUNT`.
- `api.py` — `DigitalInputControl` instance + `async_trigger_digital_input`.
- `__init__.py` — `Platform.BUTTON`.
- `translations/en.json` + `de.json` — `button.digital_input_trigger`.

## Tests

`tests/test_button.py`: 4 buttons created with correct unique_ids/visibility;
press sends the `IO=1&WEBIO=1` → `IO=0&WEBIO=1` POSTs **and** refreshes the
coordinator; friendly name resolves per language (en/de).

72 passed, coverage 91% (button.py 100%); ruff + mypy --strict clean.

> Note: `button.py` was force-added — the repo's `.gitignore` has a broad
> `custom_components` rule (intended for the dev `config/custom_components`
> symlink) that also hides new source files. Existing tracked files are
> unaffected. Flagging in case you want to scope that rule later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
