### PR TITLE
chore(gitignore): drop bare custom_components rule that hides new sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,6 @@ home-assistant.log
 home-assistant.log.*
 ozw_log.txt
 
-# Development files
-custom_components
-
 ### Linux ###
 *~
 


### PR DESCRIPTION
Fixes the unanchored `.gitignore` rule flagged in #78.

`.gitignore` had a bare `custom_components` entry under "# Development files". Because the pattern is unanchored, it matched the integration's **own** source directory at the repo root — so every *new* source file was silently dropped from `git add` unless force-added. This already bit `button.py` during the digital-input work (#77).

The dev-setup integration symlink lives under `config/`, which is already ignored by `config/*` (with `!config/configuration.yaml`). So the repo-root rule was redundant for the dev path and only harmful at the root — safe to delete outright. Removed the now-orphaned "# Development files" comment along with it.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
