### PR TITLE
chore: restore green CI on Home Assistant 2026.8 + ruff 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,11 @@ extend-exclude = [
     "config/",
     "dist/",
     "build/",
+    # Vendored from ylabonte/proconip-pypi — synced, not edited in place, so
+    # we don't enforce our own lint/format on it. (ruff 0.16 also began
+    # formatting embedded code blocks in Markdown, which tripped on the
+    # vendored README.)
+    "tools/proconip_mock/",
 ]
 
 [tool.ruff.lint]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import inspect
 import pathlib
 from collections.abc import AsyncIterator, Generator
 from typing import Any
 
+import aiohttp
 import pytest
 from aioresponses import aioresponses
 from homeassistant.const import (
@@ -19,6 +21,35 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.proconip_pool_controller.const import DOMAIN
+
+# aiohttp 3.14 made ``ClientResponse.__init__`` require a keyword-only
+# ``stream_writer`` argument, which it dereferences during init
+# (``self._output_size = stream_writer.output_size``). aioresponses 0.7.9 (the
+# latest release) builds its mocked responses without passing it, so every
+# mocked request raises ``TypeError: ... missing 1 required keyword-only
+# argument: 'stream_writer'`` once Home Assistant bundles aiohttp >= 3.14 (HA
+# Core 2026.8+). Inject a no-op stream writer when aioresponses omits it. This
+# becomes a no-op the moment aioresponses passes ``stream_writer`` itself, and
+# it never affects real requests (aiohttp always supplies a real writer). The
+# signature guard keeps us inert on aiohttp < 3.14, where ``__init__`` has no
+# such parameter and injecting one would itself raise.
+_orig_client_response_init = aiohttp.ClientResponse.__init__
+
+
+class _NoopStreamWriter:
+    """Minimal stand-in for aiohttp's stream writer in mocked responses."""
+
+    output_size = 0
+
+
+def _client_response_init_with_stream_writer(self: Any, *args: Any, **kwargs: Any) -> None:
+    if kwargs.get("stream_writer") is None:
+        kwargs["stream_writer"] = _NoopStreamWriter()
+    _orig_client_response_init(self, *args, **kwargs)
+
+
+if "stream_writer" in inspect.signature(_orig_client_response_init).parameters:
+    aiohttp.ClientResponse.__init__ = _client_response_init_with_stream_writer  # type: ignore[method-assign]
 
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 


### PR DESCRIPTION
Restores green CI on current dependencies. Both failures are pre-existing dependency/tooling drift on `main`, independent of #80 and #81 — any PR opened today inherits them. Reproduced deterministically in an isolated HA 2026.8.2 venv (not runner flakiness).

**Root cause 1 — tests (HA Core 2026.8.2 / aiohttp 3.14.3).** `pytest-homeassistant-custom-component` pulls current HA Core, which bundles aiohttp 3.14. Its `ClientResponse.__init__` now requires a keyword-only `stream_writer` that it dereferences during init. aioresponses 0.7.9 (the latest release) doesn't pass it → every mocked request raised `TypeError` → whole suite red on HA 2026.8 (73/73 still green on 2026.5.x). Not user-facing: real aiohttp responses never hit this construction path.

The `test:` commit shims a no-op `stream_writer` in `conftest.py` when aioresponses omits it, guarded by a signature check so it stays inert on aiohttp < 3.14 and self-deactivates once aioresponses passes the argument upstream.

**Root cause 2 — lint (ruff 0.16.3).** ruff 0.16 began formatting embedded code blocks in Markdown; the vendored `tools/proconip_mock/README.md` isn't ruff-formatted → `ruff format --check .` failed.

The `chore(ruff):` commit excludes `tools/proconip_mock/` (synced from `ylabonte/proconip-pypi`, not edited in place) from ruff lint/format.

**Verified** against the exact CI environment (HA 2026.8.2, aiohttp 3.14.3, ruff 0.16.3):

- `ruff format --check .` ✓
- `ruff check .` ✓
- `mypy` ✓
- `pytest` → 73 passed, coverage 91%

Merge this first; then #80 and #81 rebase onto green `main`.

_FYI, out of scope:_ the suite still emits `BasicAuth` DeprecationWarnings from the `proconip` library itself (aiohttp 4.0 removal) — warnings only, worth an upstream fix eventually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
