### PR TITLE
ci: keep docs commits out of release-please releases

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -24,7 +24,7 @@
         { "type": "perf", "section": "Performance" },
         { "type": "revert", "section": "Reverts" },
         { "type": "deps", "section": "Dependencies" },
-        { "type": "docs", "section": "Documentation", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": true },
         { "type": "refactor", "section": "Refactor", "hidden": true },
         { "type": "test", "section": "Tests", "hidden": true },
         { "type": "build", "section": "Build System", "hidden": true },


### PR DESCRIPTION
Follow-up to #84. `docs` was `hidden: false` in the release-please config, which in release-please means docs commits both appear in the changelog **and** trigger a patch release — so a README-only change (like #80) cuts a release on its own. Set `docs` to `hidden: true`.

Going forward, documentation-only changes no longer auto-trigger releases or land in the changelog. The updated README still ships at each release tag (it lives in the git tree, independent of the changelog).

Once this merges, release-please drops the Documentation entry from the pending **2.2.1** release PR (#83), leaving it a clean **Dependencies-only** release (driven by #84's deps refresh). The updated HACS-default README still rides along at the `v2.2.1` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
