### PR TITLE
chore: log mistakes in MISTAKES.md, ignore it locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,6 @@ $RECYCLE.BIN/
 # Home Assistant configuration
 config/*
 !config/configuration.yaml
+
+# Local mistake log (see "Working style" in CLAUDE.md)
+MISTAKES.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,9 @@ How the maintainer likes to collaborate with assistants on this repo:
   file. Same for removals or rewrites. Surgical edits, one concern at
   a time, tone consistent with the rest.
 
+- **Log mistakes in `MISTAKES.md`** (what happened, root cause,
+  prevention).
+
 ## Common commands
 
 All scripts cd into the repo root themselves; run them from anywhere.


### PR DESCRIPTION
Adds a Working-style rule to `CLAUDE.md`: record mistakes in
`MISTAKES.md` (what happened, root cause, prevention), so recurring
pitfalls get captured deliberately rather than re-discovered.

`MISTAKES.md` is gitignored so the log stays local per-checkout instead
of becoming shared history.

Typed `chore` (not `docs`) on purpose: `CLAUDE.md` is agent/dev
instruction, not user-facing product documentation, so it should not
surface in the user-facing changelog. (`docs` is `hidden:false` in
`.release-please-config.json`; `chore` is hidden.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)